### PR TITLE
ConfirmTokenScreen finished

### DIFF
--- a/HomeApp/app/src/main/java/com/HomeApp/screens/ConfirmTokenScreen.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/screens/ConfirmTokenScreen.kt
@@ -1,8 +1,25 @@
 package com.HomeApp.screens
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.HomeApp.ui.composables.BottomDivider
+import com.HomeApp.ui.composables.Divider.SignIn
+import com.HomeApp.ui.composables.InputType
+import com.HomeApp.ui.composables.TextInput
+import com.HomeApp.ui.navigation.ResetPassword
 
 @Composable
 fun ConfirmTokenScreen(
@@ -10,5 +27,22 @@ fun ConfirmTokenScreen(
     modifier: Modifier = Modifier,
     OnSelfClick: () -> Unit = {}
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
 
+    Column(
+        Modifier
+            .padding(24.dp)
+            .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp, alignment = Alignment.Bottom)
+    ) {
+        TextInput(
+            inputType = InputType.Token,
+            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        )
+        Button(onClick = { navController.navigate(ResetPassword.route) }, modifier = Modifier.fillMaxWidth()) {
+            Text("SUBMIT", Modifier.padding(vertical = 8.dp))
+        }
+        BottomDivider(divider = SignIn, navController = navController)
+    }
 }


### PR DESCRIPTION
This screen lets you input a token and then submit it. Pressing the button will take you to the ResetPasswordScreen. There's also a way to get back to the login screen with the divider at the bottom. No logic done.
![image](https://user-images.githubusercontent.com/82034963/223527375-e5b6b6a0-4b77-4739-bbe2-3c204456b9e1.png)