### PR TITLE
Emil/sidebar features/27 03 23

### DIFF
--- a/HomeApp/app/src/main/java/com/HomeApp/drawers/SideDrawer.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/drawers/SideDrawer.kt
@@ -28,6 +28,7 @@ import androidx.navigation.NavController
 import coil.compose.rememberAsyncImagePainter
 import com.HomeApp.ui.composables.TitledDivider
 import com.HomeApp.ui.theme.montserrat
+import com.HomeApp.util.LocalStorage
 import com.HomeApp.util.SideBarOptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -132,6 +133,9 @@ class SideDrawer(
                             navController.navigate(it.route)
                             coroutine.launch {
                                 drawerState.close()
+                            }
+                            if (it == SideBarOptions.LOGOUT) {
+                                LocalStorage.clearToken(context)
                             }
                         },
                         elevation = null,

--- a/HomeApp/app/src/main/java/com/HomeApp/drawers/SideDrawer.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/drawers/SideDrawer.kt
@@ -128,9 +128,15 @@ class SideDrawer(
                         .padding(horizontal = 15.dp)
                 ) {
                     Button(
-                        onClick = { navController.navigate(it.route) }, elevation = null,
+                        onClick = {
+                            navController.navigate(it.route)
+                            coroutine.launch {
+                                drawerState.close()
+                            }
+                        },
+                        elevation = null,
                         colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color.Transparent
+                        backgroundColor = Color.Transparent
                         ),
                         shape = RoundedCornerShape(0.dp),
                         modifier = Modifier.fillMaxHeight(),

--- a/HomeApp/app/src/main/java/com/HomeApp/screens/ProfileScreen.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/screens/ProfileScreen.kt
@@ -1,2 +1,14 @@
 package com.HomeApp.screens
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+
+@Composable
+fun ProfileScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    OnSelfClick: () -> Unit = {}
+) {
+
+}

--- a/HomeApp/app/src/main/java/com/HomeApp/ui/navigation/NavHost.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/ui/navigation/NavHost.kt
@@ -205,6 +205,20 @@ fun AnimatedAppNavHost(
                 OnSelfClick = { navController.navigateSingleTopTo(CreateAccount.route) }
             )
         }
+
+        // PROFILE
+        composable(
+            route = Profile.route,
+            enterTransition = { fadeIn(tween(defaultTween)) },
+            popEnterTransition = { fadeIn(tween(defaultTween)) },
+            exitTransition = { fadeOut(tween(defaultTween)) },
+            popExitTransition = { fadeOut(tween(defaultTween)) }
+        ) {
+            ProfileScreen(
+                navController = navController,
+                OnSelfClick = { navController.navigateSingleTopTo(Profile.route) }
+            )
+        }
     }
 }
 

--- a/HomeApp/app/src/main/java/com/HomeApp/ui/navigation/Router.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/ui/navigation/Router.kt
@@ -74,3 +74,8 @@ object CreateAccount : NavPath {
     override val icon = Icons.Rounded.Person
     override val route = "create-account"
 }
+
+object Profile : NavPath {
+    override val icon = Icons.Rounded.People
+    override val route = "profile"
+}

--- a/HomeApp/app/src/main/java/com/HomeApp/util/LocalStorage.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/util/LocalStorage.kt
@@ -91,4 +91,10 @@ object LocalStorage {
             e.printStackTrace()
         }
     }
+
+    /** "Clears" the token by updating it to an empty string */
+    fun clearToken(context: Context) {
+        localStorageData.token = ""
+        saveData(context)
+    }
 }

--- a/HomeApp/app/src/main/java/com/HomeApp/util/Values.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/util/Values.kt
@@ -4,11 +4,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Curtains
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.outlined.DoorFront
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Logout
 import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.HomeApp.ui.navigation.Home
+import com.HomeApp.ui.navigation.Loading
 
 val firebaseConfig = mapOf(
     "apiKey" to "AIzaSyBe9OfClxqevJF_7X5v2Rk1lP9EQTWv458",
@@ -26,8 +29,8 @@ val microphoneIcon: ImageVector = Icons.Rounded.Mic
 enum class SideBarOptions(val title: String, val icon: ImageVector?, val route: String) {
     PROFILE("Profile & Family", Icons.Rounded.People, Home.route),
     NOTIFICATIONS("Notifications", Icons.Rounded.Notifications, Home.route),
-    History("History", null, Home.route),
-    LOGOUT("Logout", null, Home.route),
+    History("History", Icons.Rounded.History, Home.route),
+    LOGOUT("Logout", Icons.Rounded.Logout, Loading.route),
 }
 
 val enableTopDrawer: Boolean = false

--- a/HomeApp/app/src/main/java/com/HomeApp/util/Values.kt
+++ b/HomeApp/app/src/main/java/com/HomeApp/util/Values.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.rounded.People
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.HomeApp.ui.navigation.Home
 import com.HomeApp.ui.navigation.Loading
+import com.HomeApp.ui.navigation.Profile
 
 val firebaseConfig = mapOf(
     "apiKey" to "AIzaSyBe9OfClxqevJF_7X5v2Rk1lP9EQTWv458",
@@ -27,7 +28,7 @@ val firebaseConfig = mapOf(
 val microphoneIcon: ImageVector = Icons.Rounded.Mic
 
 enum class SideBarOptions(val title: String, val icon: ImageVector?, val route: String) {
-    PROFILE("Profile & Family", Icons.Rounded.People, Home.route),
+    PROFILE("Profile & Family", Icons.Rounded.People, Profile.route),
     NOTIFICATIONS("Notifications", Icons.Rounded.Notifications, Home.route),
     History("History", Icons.Rounded.History, Home.route),
     LOGOUT("Logout", Icons.Rounded.Logout, Loading.route),


### PR DESCRIPTION
- When any option in the side drawer is selected, it will close. I thought this was the most logical thing to happen, can always change it later.
- Added icons to items in side drawer.
- Added route for profile screen
- Updated route for Profile & Family to profile screen.
- Updated route for logout to loading screen
- Added a function called "clearToken" in LocalStorage.kt that sets the token to an empty string. The function is called when the user presses the logout button

The Notifications and History options just "redirects" you to the home page again since we have no screens for those yet.

![image](https://user-images.githubusercontent.com/82034963/230625253-0fd23c82-4237-4318-a79a-e5f7d65a8791.png)